### PR TITLE
Experiments for language injection support for VADL

### DIFF
--- a/src/main/kotlin/vadl/intellijopenvadl/VadlLanguage.kt
+++ b/src/main/kotlin/vadl/intellijopenvadl/VadlLanguage.kt
@@ -1,0 +1,17 @@
+package vadl.intellijopenvadl
+
+import com.intellij.lang.Language
+import com.intellij.openapi.fileTypes.LanguageFileType
+import javax.swing.Icon
+
+object VadlLanguage : Language("VADL", "text/vadl") {
+    override fun getDisplayName(): String = "VADL"
+    private fun readResolve(): Any = VadlLanguage
+}
+
+class VadlFileType : LanguageFileType(VadlLanguage) {
+    override fun getName() = "VADL"
+    override fun getDescription() = "The Vienna Architecture Description Language"
+    override fun getDefaultExtension() = "vadl"
+    override fun getIcon(): Icon = OpenVadlIcons.PluginIcon
+}

--- a/src/main/kotlin/vadl/intellijopenvadl/VadlLanguageInjector.kt
+++ b/src/main/kotlin/vadl/intellijopenvadl/VadlLanguageInjector.kt
@@ -1,0 +1,43 @@
+package vadl.intellijopenvadl
+
+import com.intellij.lang.injection.MultiHostInjector
+import com.intellij.lang.injection.MultiHostRegistrar
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiLanguageInjectionHost
+import com.intellij.psi.PsiLiteralValue
+
+class VadlLanguageInjector : MultiHostInjector {
+
+    private val keywords = setOf("instruction set architecture")
+
+    override fun elementsToInjectIn(): List<Class<out PsiElement>> =
+        listOf(PsiLiteralValue::class.java)
+
+    override fun getLanguagesToInject(registrar: MultiHostRegistrar, context: PsiElement) {
+        val lit = context as? PsiLiteralValue ?: return
+        val host = lit as? PsiLanguageInjectionHost ?: return
+        if (!host.isValidHost) return
+
+        val value = lit.value as? String ?: return
+        if (keywords.none { value.contains(it) }) return
+
+        val text = lit.text ?: return
+
+        val rangeInHost = when {
+            // normal Java string: "..."
+            text.length >= 2 && text.first() == '"' && text.last() == '"' ->
+                TextRange(1, text.length - 1)
+
+            // Java text block: """ ... """
+            text.startsWith("\"\"\"") && text.endsWith("\"\"\"") && text.length >= 6 ->
+                TextRange(3, text.length - 3)
+
+            else -> return
+        }
+
+        registrar.startInjecting(VadlLanguage)
+        registrar.addPlace(null, null, host, rangeInHost)
+        registrar.doneInjecting()
+    }
+}

--- a/src/main/kotlin/vadl/intellijopenvadl/psi/VadlPsi.kt
+++ b/src/main/kotlin/vadl/intellijopenvadl/psi/VadlPsi.kt
@@ -1,0 +1,89 @@
+package vadl.intellijopenvadl.psi
+
+import com.intellij.extapi.psi.ASTWrapperPsiElement
+import com.intellij.extapi.psi.PsiFileBase
+import com.intellij.lang.ASTNode
+import com.intellij.lang.ParserDefinition
+import com.intellij.lang.PsiBuilder
+import com.intellij.lang.PsiParser
+import com.intellij.lexer.Lexer
+import com.intellij.lexer.LexerBase
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.project.Project
+import com.intellij.psi.FileViewProvider
+import com.intellij.psi.PsiElement
+import com.intellij.psi.tree.IElementType
+import com.intellij.psi.tree.IFileElementType
+import com.intellij.psi.tree.TokenSet
+import vadl.intellijopenvadl.VadlFileType
+import vadl.intellijopenvadl.VadlLanguage
+
+object VadlTokenTypes {
+    val FILE = IFileElementType(VadlLanguage)
+    val CONTENT = IElementType("CONTENT", VadlLanguage)
+}
+
+class VadlFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider, VadlLanguage) {
+    override fun getFileType(): FileType = VadlFileType()
+    override fun toString() = "VADL File"
+}
+
+class VadlLexer : LexerBase() {
+    private var buffer: CharSequence = ""
+    private var start = 0
+    private var end = 0
+    private var tokenReturned = false
+
+    override fun start(buffer: CharSequence, startOffset: Int, endOffset: Int, initialState: Int) {
+        this.buffer = buffer
+        this.start = startOffset
+        this.end = endOffset
+        this.tokenReturned = false
+    }
+
+    override fun getState(): Int = 0
+
+    override fun getTokenType(): IElementType? =
+        if (tokenReturned || start >= end) null else VadlTokenTypes.CONTENT
+
+    override fun getTokenStart(): Int = start
+    override fun getTokenEnd(): Int = end
+
+    override fun advance() {
+        tokenReturned = true
+    }
+
+    override fun getBufferSequence(): CharSequence = buffer
+    override fun getBufferEnd(): Int = end
+}
+
+
+class VadlParser : PsiParser {
+    override fun parse(root: IElementType, builder: PsiBuilder): ASTNode {
+        val mark = builder.mark()
+
+        while (!builder.eof()) {
+            builder.advanceLexer()
+        }
+
+        mark.done(root)
+        return builder.treeBuilt
+    }
+}
+
+class VadlPsiElement(node: ASTNode) : ASTWrapperPsiElement(node)
+
+class VadlParserDefinition : ParserDefinition {
+
+    override fun createLexer(project: Project?): Lexer = VadlLexer()
+    override fun createParser(project: Project?): PsiParser = VadlParser()
+
+    override fun getFileNodeType(): IFileElementType = VadlTokenTypes.FILE
+
+    override fun getWhitespaceTokens(): TokenSet = TokenSet.EMPTY
+    override fun getCommentTokens(): TokenSet = TokenSet.EMPTY
+    override fun getStringLiteralElements(): TokenSet = TokenSet.EMPTY
+
+    override fun createElement(node: ASTNode): PsiElement = VadlPsiElement(node)
+    override fun createFile(viewProvider: FileViewProvider) = VadlFile(viewProvider)
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -41,10 +41,15 @@
         <platform.lsp.serverSupportProvider implementation="vadl.intellijopenvadl.OpenVadlLspServerSupportProvider"/>
         <notificationGroup id="OpenVADL" displayType="BALLOON"/>
         <applicationConfigurable
-            parentId="tools"
-            instance="vadl.intellijopenvadl.OpenVadlSettingsConfigurable"
-            id="vadl.intellijopenvadl.OpenVadlSettingsConfigurable"
-            displayName="OpenVADL"/>
+                parentId="tools"
+                instance="vadl.intellijopenvadl.OpenVadlSettingsConfigurable"
+                id="vadl.intellijopenvadl.OpenVadlSettingsConfigurable"
+                displayName="OpenVADL"/>
         <applicationService serviceImplementation="vadl.intellijopenvadl.OpenVadlSettings"/>
+
+        <fileType name="VADL" language="VADL" extensions="vadl"
+                  implementationClass="vadl.intellijopenvadl.VadlFileType"/>
+        <lang.parserDefinition language="VADL" implementationClass="vadl.intellijopenvadl.psi.VadlParserDefinition"/>
+        <multiHostInjector implementation="vadl.intellijopenvadl.VadlLanguageInjector"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
@flofriday 

Here's the current/final state of my experiments to support language injection for VADL. Feel free to modify, or abandon the PR.

Fyi if you're interested, I invited you to the plugin repo where I used the Coco/R generated scanner to integrate IntelliJ syntax highlighting & language injections: https://github.com/rascmatt/tifl-plugin

---

Originally I thought that adding the `VadlLanguage` and `VadlFileType` would be enough, but it turns out that language injection seems to only work in combination with an implementation of IntelliJ's PSI framework.

I also tried to comply by providing a 'dummy' lexer & parser, and even tried a custom language injector, but without success. Intellj just ignores the LSP in these scenarios.